### PR TITLE
Add ... for longer bodies on truncate. Blur event listener not ready

### DIFF
--- a/app/assets/javascripts/edit_ideas.js
+++ b/app/assets/javascripts/edit_ideas.js
@@ -13,7 +13,11 @@ var allowTitleEdits = function(that, requestService) {
   var idea = that.closest('.idea')
   var element = $(idea).find('.title')
 
-  element.attr('contentEditable', true)
+  element.attr('contentEditable', true).focus()
+
+  element.on('blur', function(e){
+    updateTitle(idea, element, e, requestService)
+  })
 
   $(idea).on('keydown', function(e){
     updateTitle(idea, element, e, requestService)

--- a/app/assets/javascripts/edit_ideas.js
+++ b/app/assets/javascripts/edit_ideas.js
@@ -14,8 +14,9 @@ var allowTitleEdits = function(that, requestService) {
   var element = $(idea).find('.title')
 
   element.attr('contentEditable', true).focus()
-
+  debugger
   element.on('blur', function(e){
+    debugger
     updateTitle(idea, element, e, requestService)
   })
 

--- a/app/assets/javascripts/render_ideas.js
+++ b/app/assets/javascripts/render_ideas.js
@@ -26,6 +26,6 @@ var truncate = function(string){
   if (idx == -1 || string.length < 100) {
     return shortendString
   } else {
-    return shortendString.substring(0, idx)
+    return shortendString.substring(0, idx) + '...'
   }
 }


### PR DESCRIPTION
Working on adding blur event handling for title or body edits. Have tried adding 'blur' to the title keydown event in title edits and creating a second event listener specific to blur after a user has clicked for an in line edit but the code doesn't get executed.
